### PR TITLE
Add log to trigger image build for submoduling g3w-api

### DIFF
--- a/deployment/scripts/setup.sh
+++ b/deployment/scripts/setup.sh
@@ -15,6 +15,7 @@ pip3 install -r requirements_huey.txt
 git submodule add -f https://github.com/g3w-suite/g3w-admin-frontend.git  g3w-admin/frontend
 
 # Dam monitor
+echo "Adding dam_monitor and g3w_api"
 git submodule add -f https://github.com/kartoza/eoi-g3w-dam-monitor.git  g3w-admin/dam_monitor
 git submodule add -f https://github.com/kartoza/eoi-g3w-api.git  g3w-admin/g3w_api
 


### PR DESCRIPTION
This PR addresses ALCOA Australia issue in https://github.com/EOIntelligence/SAR_SMM/issues/115
A new log is added to trigger pulling newest g3w-api.